### PR TITLE
Integrate Minecraft Server with systemd

### DIFF
--- a/roles/minecraft/tasks/main.yml
+++ b/roles/minecraft/tasks/main.yml
@@ -33,3 +33,17 @@
     src: server
     dest: "~/{{ mc_dir }}/"
     mode: a+x
+
+- name: copy systemd service config in place.
+  become: true
+  template:
+    src: minecraft.service
+    dest: "/etc/systemd/system/"
+
+- name: start & enable the minecraft service.
+  become: true
+  ansible.builtin.systemd:
+    name: minecraft
+    state: started
+    daemon_reload: yes
+    enabled: yes

--- a/roles/minecraft/templates/minecraft.service
+++ b/roles/minecraft/templates/minecraft.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=Minecraft Server
+Documentation=
+
+Wants=network.target
+After=network.target
+
+[Service]
+WorkingDirectory=/home/{{ remote_user }}/{{ mc_dir }}
+Type=forking
+
+User={{ remote_user }}
+Group={{ remote_user }}
+Nice=5
+KillMode=none
+SuccessExitStatus=0 1
+
+Restart=always
+
+ExecStart=/home/{{ remote_user }}/{{ mc_dir }}/server start
+ExecStop=/home/{{ remote_user }}/{{ mc_dir }}/server stop
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/minecraft/templates/server
+++ b/roles/minecraft/templates/server
@@ -55,6 +55,13 @@ start_server() {
   cd "$( dirname "$0" )"
   local server_path="~/{{ mc_dir }}"
   local server_jar="$(ls | grep paper-*.jar)"
+
+  if [ -z "${server_jar}" ]; then
+    printf "error: no server file found. Downloading latest."
+    update_server
+  fi
+
+  server_jar="$(ls | grep paper-*.jar)"
   local server_flags="-Xms4G -Xmx4G -XX:+UseG1GC -XX:+ParallelRefProcEnabled -XX:MaxGCPauseMillis=200 -XX:+UnlockExperimentalVMOptions -XX:+DisableExplicitGC -XX:+AlwaysPreTouch -XX:G1NewSizePercent=30 -XX:G1MaxNewSizePercent=40 -XX:G1HeapRegionSize=8M -XX:G1ReservePercent=20 -XX:G1HeapWastePercent=5 -XX:G1MixedGCCountTarget=4 -XX:InitiatingHeapOccupancyPercent=15 -XX:G1MixedGCLiveThresholdPercent=90 -XX:G1RSetUpdatingPauseTimePercent=5 -XX:SurvivorRatio=32 -XX:+PerfDisableSharedMem -XX:MaxTenuringThreshold=1"
   local server_screen_name="minecraft-server"
   local server_stats="$(server_status)"
@@ -134,8 +141,11 @@ backup_server() {
 }
 
 update_server() {
+  # PaperMC's API sucks now so we have to manually specify version & build IDs unless we convert this
+  # To something that can more easily parse the REST data like python or node. SMH
   local PAPERMC_VERSION="1.17.1"
-  local PAPERMC_URL="https://papermc.io/api/v1/paper/${PAPERMC_VERSION}/latest/download"
+  local PAPERMC_BUILD="391"
+  local PAPERMC_URL="https://papermc.io/api/v2/projects/paper/versions/${PAPERMC_VERSION}/builds/${PAPERMC_BUILD}/downloads/paper-${PAPERMC_VERSION}-${PAPERMC_BUILD}.jar"
   local server_jar="$(ls | grep paper-*.jar)"
   local SERVER_BACKUP_FOLDER="./server_backups"
   local server_stats="$(server_status)"
@@ -147,8 +157,10 @@ update_server() {
       mkdir -p "${SERVER_BACKUP_FOLDER}"
     fi
 
-    printf "Backing up current server file...\n"
-    mv "${server_jar}" "${SERVER_BACKUP_FOLDER}/"
+    if [ ! -z "${server_jar}" ]; then
+      printf "Backing up current server file...\n"
+      mv "${server_jar}" "${SERVER_BACKUP_FOLDER}/"
+    fi
 
     printf "Downloading latest version of papermc..."
     if wget --trust-server-names --content-disposition "${PAPERMC_URL}"; then

--- a/run.yml
+++ b/run.yml
@@ -31,7 +31,13 @@
     - 'vars/vault.yml'
   roles:
     - role: matrix
-    - role: minecraft
-      tags: minecraft
     - role: ironicbadger.ansible_role_docker_compose_generator
       tags: compose
+
+# Deploy Minecraft Server
+- hosts: matrix
+  vars_files:
+    - 'vars/vault.yml'
+  roles:
+    - role: minecraft
+      tags: minecraft


### PR DESCRIPTION
This gets us onto the PaperMC v2 API since v1 is apparently dead now.  Might need to spend some time tweaking the server script because I'm really not thrilled with the idea of manually keying in new build IDs...

ANYWAY this also will create a systemd service so we can manage the server automatically vs ssh'ing in after reboots to kick up the server again.