### PR TITLE
Manage Restic & Autorestic with Ansible

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -3,7 +3,7 @@ extends: default
 
 rules:
   line-length:
-    max: 90
+    max: 130
     level: warning
 
 ignore: |

--- a/roles/restic/defaults/main.yml
+++ b/roles/restic/defaults/main.yml
@@ -1,0 +1,15 @@
+---
+
+binfile_install_directory: /usr/local/bin
+
+restic_binary: restic
+restic_install_path: "{{ binfile_install_directory }}/{{ restic_binary }}"
+restic_download_directory: "/tmp/restic"
+restic_repo_url: "https://github.com/restic/restic/releases/download"
+restic_releases_api: "https://api.github.com/repos/restic/restic/releases/latest"
+
+autorestic_binary: autorestic
+autorestic_install_path: "{{ binfile_install_directory }}/{{ autorestic_binary }}"
+autorestic_download_directory: "/tmp/autorestic"
+autorestic_repo_url: "https://github.com/cupcakearmy/autorestic/releases/download"
+autorestic_releases_api: "https://api.github.com/repos/cupcakearmy/autorestic/releases/latest"

--- a/roles/restic/tasks/install_autorestic.yml
+++ b/roles/restic/tasks/install_autorestic.yml
@@ -1,0 +1,63 @@
+---
+
+- name: include OS-specific variables.
+  include_vars: "{{ ansible_distribution }}.yml"
+
+- name: "Check if {{ autorestic_install_path }} exists."
+  stat:
+    path: "{{ autorestic_install_path }}"
+  register: is_installed
+
+- name: Set autorestic installation status.
+  set_fact:
+    autorestic_installed: "{{ is_installed.stat.exists }}"
+
+- name: Get autorestic version.
+  shell: |
+    {{ is_installed.stat.path }} --version | \
+    grep -oP 'autorestic\ version\ \K[0-9]*\.[0-9]*\.[0-9]*'
+  register: installed_version_register
+  changed_when: false
+  when: autorestic_installed == True
+
+- name: Query GitHub API for autorestic release info.
+  uri:
+    url: "{{ autorestic_releases_api }}"
+    return_content: true
+  register: release_version_register
+
+- name: Identify latest version of autorestic.
+  set_fact:
+    autorestic_ver: "{{ release_version_register.json.tag_name|regex_replace('v') }}"
+
+- block:
+    - name: "Ensure {{ autorestic_download_directory }} does not exist."
+      file:
+        path: "{{ autorestic_download_directory }}"
+        state: absent
+
+    - name: "Create {{ autorestic_download_directory }}."
+      file:
+        path: "{{ autorestic_download_directory }}"
+        state: directory
+        mode: 0755
+
+    - name: Download autorestic.
+      get_url:
+        url: "{{ autorestic_repo_url }}/v{{ autorestic_ver }}/autorestic_{{ autorestic_ver }}_{{ autorestic_distro }}.bz2"
+        dest: "{{ autorestic_download_directory }}"
+        force: true
+        owner: root
+        group: root
+        mode: +x
+
+    - name: Identify autorestic compressed file.
+      set_fact: file_name="autorestic_{{ autorestic_ver }}_{{ autorestic_distro }}.bz2"
+
+    - name: Unzip and update autorestic.
+      shell: |
+        cd {{ autorestic_download_directory }} &&
+        bzip2 -d {{ file_name }} &&
+        mv {{ file_name | regex_replace('.bz2') }} {{ autorestic_install_path }}
+
+  when: autorestic_installed == False or ( autorestic_installed == True and installed_version_register.stdout != autorestic_ver)

--- a/roles/restic/tasks/install_restic.yml
+++ b/roles/restic/tasks/install_restic.yml
@@ -1,0 +1,63 @@
+---
+
+- name: include OS-specific variables.
+  include_vars: "{{ ansible_distribution }}.yml"
+
+- name: "Check if {{ restic_install_path }} exists."
+  stat:
+    path: "{{ restic_install_path }}"
+  register: is_installed
+
+- name: Set restic installation status.
+  set_fact:
+    restic_installed: "{{ is_installed.stat.exists }}"
+
+- name: Get restic version.
+  shell: |
+    {{ is_installed.stat.path }} version | \
+    grep -oP 'restic\ \K[0-9]*\.[0-9]*\.[0-9]*'
+  register: installed_version_register
+  changed_when: false
+  when: restic_installed == True
+
+- name: Query GitHub API for restic release info.
+  uri:
+    url: "{{ restic_releases_api }}"
+    return_content: true
+  register: release_version_register
+
+- name: Identify latest version of restic.
+  set_fact:
+    restic_ver: "{{ release_version_register.json.tag_name|regex_replace('v') }}"
+
+- block:
+    - name: "Ensure {{ restic_download_directory }} does not exist."
+      file:
+        path: "{{ restic_download_directory }}"
+        state: absent
+
+    - name: "Create {{ restic_download_directory }}."
+      file:
+        path: "{{ restic_download_directory }}"
+        state: directory
+        mode: 0755
+
+    - name: Download restic.
+      get_url:
+        url: "{{ restic_repo_url }}/v{{ restic_ver }}/restic_{{ restic_ver }}_{{ restic_distro }}.bz2"
+        dest: "{{ restic_download_directory }}"
+        force: true
+        owner: root
+        group: root
+        mode: +x
+
+    - name: Identify restic compressed file.
+      set_fact: file_name="restic_{{ restic_ver }}_{{ restic_distro }}.bz2"
+
+    - name: Unzip and update restic.
+      shell: |
+        cd {{ restic_download_directory }} &&
+        bzip2 -d {{ file_name }} &&
+        mv {{ file_name | regex_replace('.bz2') }} {{ restic_install_path }}
+
+  when: restic_installed == False or (restic_installed == True and installed_version_register.stdout != restic_ver )

--- a/roles/restic/tasks/main.yml
+++ b/roles/restic/tasks/main.yml
@@ -1,0 +1,7 @@
+---
+
+- name: install restic
+  include: install_restic.yml
+
+- name: install autorestic
+  include: install_autorestic.yml

--- a/roles/restic/vars/Debian.yml
+++ b/roles/restic/vars/Debian.yml
@@ -1,0 +1,4 @@
+---
+
+restic_distro: linux_arm
+autorestic_distro: "{{ restic_distro }}"

--- a/roles/restic/vars/Ubuntu.yml
+++ b/roles/restic/vars/Ubuntu.yml
@@ -1,0 +1,4 @@
+---
+
+restic_distro: linux_amd64
+autorestic_distro: "{{ restic_distro }}"

--- a/run.yml
+++ b/run.yml
@@ -1,11 +1,13 @@
 ---
 # Update All
 - hosts: all
+  become: true
   vars_files:
     - 'vars/vault.yml'
   roles:
     - role: base
-      tags: update
+    - role: restic
+  tags: update
 
 # Update Docker services
 - hosts: docker
@@ -13,7 +15,7 @@
     - 'vars/vault.yml'
   roles:
     - role: docker
-      tags: docker
+  tags: docker
 
 # Deploy Docker services on Calpamos
 - hosts: calpamos
@@ -21,9 +23,8 @@
     - 'vars/vault.yml'
   roles:
     - role: calpamos
-      tags: compose
     - role: ironicbadger.ansible_role_docker_compose_generator
-      tags: compose
+  tags: compose
 
 # Deploy Docker services on Matrix
 - hosts: matrix
@@ -32,7 +33,7 @@
   roles:
     - role: matrix
     - role: ironicbadger.ansible_role_docker_compose_generator
-      tags: compose
+  tags: compose
 
 # Deploy Minecraft Server
 - hosts: matrix
@@ -40,4 +41,4 @@
     - 'vars/vault.yml'
   roles:
     - role: minecraft
-      tags: minecraft
+  tags: minecraft


### PR DESCRIPTION
Sets up a role to manage installation (and updates) of the restic & autorestic binary files.  This is sort of hacky because I was too lazy to add vars files for each permutation of the `arm` architecture (on my pis I seem to at least have three: `armv6l`, `armv7l`, and `aarch64`).  For now I'm just assuming all `Debian` distros in my network are Raspbian, and therefore can use the 32-bit build of both binaries, while anything `Ubuntu` is `amd64`.