### PR TITLE
Add Matrix's Autorestic Config

### DIFF
--- a/roles/matrix/tasks/configure-autorestic.yml
+++ b/roles/matrix/tasks/configure-autorestic.yml
@@ -1,0 +1,14 @@
+---
+
+- name: copy autorestic config in place.
+  template:
+    src: ".autorestic.yml"
+    dest: "/home/{{ remote_user }}"
+
+- name: schedule autorestic with cron
+  ansible.builtin.cron:
+    name: autorestic backup
+    job: "/usr/local/bin/autorestic --ci cron"
+    user: "{{ remote_user }}"
+    minute: "33"
+    hour: "3"

--- a/roles/matrix/tasks/main.yml
+++ b/roles/matrix/tasks/main.yml
@@ -2,4 +2,6 @@
 
 - name: deploy docker services
   include: deploy-docker.yml
-  tags: compose
+
+- name: configure autorestic
+  include: configure-autorestic.yml

--- a/roles/matrix/templates/.autorestic.yml
+++ b/roles/matrix/templates/.autorestic.yml
@@ -1,0 +1,25 @@
+backends:
+  hdd:
+    type: local
+    path: "{{ matrix_restic_backup_path }}"
+    key: "{{ matrix_restic_key }}"
+
+locations:
+  docker_data:
+    from: "{{ appdata_path }}"
+    to:
+    - hdd
+    cron: 33 3 * * *
+    options:
+      forget:
+        keep-last:
+        - "5"
+  minecraft_data:
+    from: "/home/{{ remote_user }}/{{ mc_dir }}"
+    to:
+    - hdd
+    cron: 33 3 * * *
+    options:
+      forget:
+        keep-last:
+        - "5"


### PR DESCRIPTION
Deploys matrix's autorestic configuration file & ensures the cron entry is activated.  Does not do a presence check for the restic/autorestic binaries right now so this isn't perfect.  May re-nest this back under the "restic" role later ... still trying to figure out which option makes the most sense.