### PR TITLE
Update to Paper 1.18.1

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -15,6 +15,8 @@ jobs:
         with:
           targets: "./run.yml"
           args: "-q -x 305,301"
+          override-deps: |
+            rich>=9.5.1,<11.0.0
 
   yamllint:
     runs-on: ubuntu-latest

--- a/roles/minecraft/templates/server
+++ b/roles/minecraft/templates/server
@@ -143,7 +143,7 @@ backup_server() {
 update_server() {
   # PaperMC's API sucks now so we have to manually specify version & build IDs unless we convert this
   # To something that can more easily parse the REST data like python or node. SMH
-  local PAPERMC_VERSION="1.17.1"
+  local PAPERMC_VERSION="1.18.1"
   local PAPERMC_BUILD_API="https://papermc.io/api/v2/projects/paper/versions/${PAPERMC_VERSION}"
   
   if [ ! command -v jq ]; then


### PR DESCRIPTION
Looks like this is "stable" now.

Patches an unrelated issue with dependencies in the ansible-lint-action package.