### PR TITLE
Use Make to Deploy/Update Minecraft Server

### DIFF
--- a/makefile
+++ b/makefile
@@ -17,3 +17,6 @@ update-all:
 
 update-docker-images:
 	ansible-playbook run.yml --tags docker
+
+update-minecraft:
+	ansible-playbook run.yml --tags minecraft

--- a/roles/minecraft/templates/minecraft.service
+++ b/roles/minecraft/templates/minecraft.service
@@ -15,7 +15,7 @@ Nice=5
 KillMode=none
 SuccessExitStatus=0 1
 
-Restart=always
+Restart=on-failure
 
 ExecStartPre=/home/{{ remote_user }}/{{ mc_dir }}/server update
 ExecStart=/home/{{ remote_user }}/{{ mc_dir }}/server start


### PR DESCRIPTION
Add a `make` convenience command to deploy/update minecraft server configuration.
Also try setting the systemd service to `Restart=on-failure` instead of `Restart=always`.  The latter seems to cause issues when trying to stop/start the service via ansible.