### PR TITLE
Make Ansible Linting Work Again

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Lint Ansible Playbook
-        uses: ansible/ansible-lint-action@master
+        uses: ansible/ansible-lint-action@main
         with:
           targets: "./run.yml"
           args: "-q -x 305,301"


### PR DESCRIPTION
Looks like the branch name changed which was blowing up PR/merge builds.  This tries to fix it.