### PR TITLE
Correctly Pass 'Become' As Extra Var When Including Tasks

### DIFF
--- a/roles/ytdlp/tasks/main.yml
+++ b/roles/ytdlp/tasks/main.yml
@@ -1,13 +1,16 @@
 ---
 
 - name: "Install pre-requisites."
-  become: true
   include_tasks: install-prereqs.yml
+  vars:
+    ansible_become: true
 
 - name: "Deploy yt-dlp."
-  become: true
   include_tasks: install-yt-dlp.yml
+  vars:
+    ansible_become: true
 
 - name: "Configure yt-dlp."
-  become: true
   include_tasks: configure-yt-dlp.yml
+  vars:
+    ansible_become: true


### PR DESCRIPTION
After switching from `include:` to `include_tasks` the ytdlp role broke.  Looks like if you want to run a whole included task as sudo you need to pass it in a `vars:` declaration.  Weird.

Documented here:
https://stackoverflow.com/questions/56558841/include-tasks-does-not-work-with-become-after-upgrade-to-ansible-2-8