### PR TITLE
Only Run Linters When Pushing/Pull Requesting Main Branch

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -3,7 +3,11 @@
 name: Run Linters
 
 # yamllint disable-line rule:truthy
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+    branches:
+      - main
 
 jobs:
   ansiblelint:


### PR DESCRIPTION
Seems wasteful to run linters after every push.  Try setting them to trigger only once a PR has been opened (or if I've pushed directly to main).