### PR TITLE
Switch to Paperless-ngx

### DIFF
--- a/host_vars/matrix.yml
+++ b/host_vars/matrix.yml
@@ -8,16 +8,16 @@ docker_users:
 
 appdata_path: "/home/{{ matrix_user }}/appdata"
 containers:
-  - service_name: paperless-ng
-    container_name: paperless-ng
-    image: lscr.io/linuxserver/paperless-ng
+  - service_name: paperless-ngx
+    container_name: paperless-ngx
+    image: lscr.io/linuxserver/paperless-ngx:latest
     active: true
     ports:
       - "{{ secret_paperless_port }}:{{ secret_paperless_port }}"
     include_global_env_vars: true
     volumes:
-      - "{{ appdata_path }}/paperless-ng/config:/config"
-      - "{{ appdata_path }}/paperless-ng/data:/data"
+      - "{{ appdata_path }}/paperless-ngx/config:/config"
+      - "{{ appdata_path }}/paperless-ngx/data:/data"
     restart: unless-stopped
   ###
   - service_name: jellyfin

--- a/roles/matrix/tasks/deploy-docker.yml
+++ b/roles/matrix/tasks/deploy-docker.yml
@@ -17,7 +17,7 @@
     - homer
     - jellyfin
     - mariadb
-    - paperless-ng
+    - paperless-ngx
     - podgrab
     - postgresql
     - scrutiny


### PR DESCRIPTION
Seems like this is the way forward and it works as a drop-in replacement for the old paperless-ng compose file.