### PR TITLE
Switch to Official Scrutiny Omnibus

### DIFF
--- a/host_vars/matrix.yml
+++ b/host_vars/matrix.yml
@@ -96,21 +96,20 @@ containers:
   ###
   - service_name: scrutiny
     container_name: scrutiny
-    image: ghcr.io/linuxserver/scrutiny:8e34ef8d-ls35
+    image: ghcr.io/analogj/scrutiny:master-omnibus
     active: true
     privileged: true
     cap_add:
       - SYS_RAWIO
       - SYS_ADMIN
     include_global_env_vars: true
-    environment:
-      - SCRUTINY_WEB=true
-      - SCRUTINY_COLLECTOR=true
     volumes:
-      - "{{ appdata_path }}/scrutiny:/config"
+      - "{{ appdata_path }}/scrutiny:/opt/scrutiny/config"
+      - "{{ appdata_path }}/influxdb:/opt/scrutiny/influxdb"
       - /run/udev:/run/udev:ro
     ports:
       - "{{ secret_scrutiny_host_port }}:{{ secret_scrutiny_client_port }}"
+      - "{{ secret_influxdb_port }}:{{ secret_influxdb_port }}"
     devices: "{{ matrix_all_disks }}"
     restart: unless-stopped
   ###

--- a/roles/matrix/tasks/deploy-docker.yml
+++ b/roles/matrix/tasks/deploy-docker.yml
@@ -22,6 +22,7 @@
     - podgrab
     - postgresql
     - scrutiny
+    - influxdb
     - uptime-kuma
 
 - name: deploy homer assets


### PR DESCRIPTION
Moves me over to analogj's official omnibus package for scrutiny following linuxserver.io's deprecation notice:
https://info.linuxserver.io/issues/2022-06-13-scrutiny/